### PR TITLE
Update x/tools to fix panic in tests

### DIFF
--- a/.github/workflows/testandvet.yml
+++ b/.github/workflows/testandvet.yml
@@ -23,21 +23,12 @@ jobs:
 
     steps:
     - name: Install Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
-        go-version: 1.16.x
+        go-version: 1.23.x
 
     - name: Checkout code
-      uses: actions/checkout@v2
-
-    - name: Cache Go module and build cache
-      uses: actions/cache@v2
-      with:
-        key: go-${{ hashFiles('**/go.sum') }}
-        path: |
-          ~/go/pkg/mod
-        restore-keys: |
-          go-
+      uses: actions/checkout@v4
 
     - name: Install tennvet
       run: |

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,10 @@
 module github.com/gostaticanalysis/forcetypeassert
 
-go 1.12
+go 1.18
 
-require golang.org/x/tools v0.0.0-20190321232350-e250d351ecad
+require golang.org/x/tools v0.13.0
+
+require (
+	golang.org/x/mod v0.12.0 // indirect
+	golang.org/x/sys v0.12.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,7 @@
-golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
-golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
-golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-golang.org/x/tools v0.0.0-20190321232350-e250d351ecad h1:tYrC3aF7wTeS1noni7wCGu94xeMVu0dxOdFufzx/VM8=
-golang.org/x/tools v0.0.0-20190321232350-e250d351ecad/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
+golang.org/x/mod v0.12.0 h1:rmsUpXtvNzj340zd98LZ4KntptpfRHwpFOHG188oHXc=
+golang.org/x/mod v0.12.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
+golang.org/x/sync v0.3.0 h1:ftCYgMx6zT/asHUrPw8BLLscYtGznsLAnjq5RH9P66E=
+golang.org/x/sys v0.12.0 h1:CM0HF96J0hcLAwsHPJZjfdNzs0gftsLfgKt57wWHJ0o=
+golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/tools v0.13.0 h1:Iey4qkscZuv0VvIt8E0neZjtPVQFSc870HQ448QgEmQ=
+golang.org/x/tools v0.13.0/go.mod h1:HvlwmtVNQAhOuCjW7xxvovg8wbNq7LwfXh/k7wXUl58=


### PR DESCRIPTION
This PR fixes panic in tests when running with Go 1.23.

`golang.org/x/tools` requires `go 1.18` in `go.mod.`


<details><summary>Details</summary>
<p>

```sh
❯ go version
go version go1.23.3 darwin/arm64
❯ go test ./...
?   	github.com/gostaticanalysis/forcetypeassert/cmd/forcetypeassert	[no test files]
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x104be46c4]

goroutine 7 [running]:
go/types.(*Checker).handleBailout(0x1400053ac40, 0x140002b7c98)
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/check.go:404 +0x9c
panic({0x104ce37c0?, 0x104eb0330?})
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/runtime/panic.go:785 +0x124
go/types.(*StdSizes).Sizeof(0x0, {0x104d2c6e8, 0x104eb3660})
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/sizes.go:229 +0x314
go/types.(*Config).sizeof(...)
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/sizes.go:334
go/types.representableConst.func1({0x104d2c6e8?, 0x104eb3660?})
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/const.go:77 +0x90
go/types.representableConst({0x104d2dae8, 0x104ea7aa0}, 0x1400053ac40, 0x104eb3660, 0x140002b6ab8)
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/const.go:93 +0x134
go/types.(*Checker).representation(0x1400053ac40, 0x1400051f440, 0x104eb3660)
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/const.go:257 +0x68
go/types.(*Checker).implicitTypeAndValue(0x1400053ac40, 0x1400051f440, {0x104d2c6e8, 0x104eb3660})
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/expr.go:377 +0x304
go/types.(*Checker).convertUntyped(0x1400053ac40, 0x1400051f440, {0x104d2c6e8, 0x104eb3660})
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/const.go:290 +0x30
go/types.(*Checker).matchTypes(0x1400053ac40, 0x1400051f400, 0x1400051f440)
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/expr.go:928 +0x7c
go/types.(*Checker).binary(0x1400053ac40, 0x1400051f400, {0x104d2d188, 0x14000528210}, {0x104d2cd08, 0x140005167e0}, {0x104d2cd38, 0x14000516800}, 0x28, 0x3be93)
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/expr.go:802 +0x114
go/types.(*Checker).exprInternal(0x1400053ac40, 0x0, 0x1400051f400, {0x104d2d188, 0x14000528210}, {0x0, 0x0})
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/expr.go:1452 +0x1d4
go/types.(*Checker).rawExpr(0x1400053ac40, 0x0, 0x1400051f400, {0x104d2d188?, 0x14000528210?}, {0x0?, 0x0?}, 0x0)
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/expr.go:981 +0x120
go/types.(*Checker).expr(0x1400053ac40, 0x104d2c350?, 0x1400051f400, {0x104d2d188?, 0x14000528210?})
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/expr.go:1549 +0x38
go/types.(*Checker).stmt(0x1400053ac40, 0x0, {0x104d2d308, 0x1400051e6c0})
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/stmt.go:579 +0xa3c
go/types.(*Checker).stmtList(0x1400053ac40, 0x0, {0x14000516960?, 0x1400053ac40?, 0x140002b7a98?})
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/stmt.go:121 +0x88
go/types.(*Checker).funcBody(0x1400053ac40, 0x104d2cd08?, {0x1400050e1a8?, 0x104d2ff18?}, 0x1400051f140, 0x140005282a0, {0x0?, 0x0?})
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/stmt.go:41 +0x218
go/types.(*Checker).funcDecl.func1()
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/decl.go:888 +0x44
go/types.(*Checker).processDelayed(0x1400053ac40, 0x0)
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/check.go:516 +0x12c
go/types.(*Checker).checkFiles(0x1400053ac40, {0x14000504040, 0x1, 0x1})
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/check.go:462 +0x1b4
go/types.(*Checker).Files(0x1400011e780?, {0x14000504040?, 0x14000500300?, 0x4?})
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/check.go:422 +0x80
golang.org/x/tools/go/packages.(*loader).loadPackage(0x1400011e780, 0x140003c05e0)
	/Users/Oleksandr_Redko/go/pkg/mod/golang.org/x/tools@v0.0.0-20190321232350-e250d351ecad/go/packages/packages.go:716 +0x4f0
golang.org/x/tools/go/packages.(*loader).loadRecursive.func1()
	/Users/Oleksandr_Redko/go/pkg/mod/golang.org/x/tools@v0.0.0-20190321232350-e250d351ecad/go/packages/packages.go:574 +0x178
sync.(*Once).doSlow(0x0?, 0x0?)
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/sync/once.go:76 +0xf8
sync.(*Once).Do(...)
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/sync/once.go:67
golang.org/x/tools/go/packages.(*loader).loadRecursive(0x0?, 0x0?)
	/Users/Oleksandr_Redko/go/pkg/mod/golang.org/x/tools@v0.0.0-20190321232350-e250d351ecad/go/packages/packages.go:561 +0x48
golang.org/x/tools/go/packages.(*loader).loadRecursive.func1.1(0x0?)
	/Users/Oleksandr_Redko/go/pkg/mod/golang.org/x/tools@v0.0.0-20190321232350-e250d351ecad/go/packages/packages.go:568 +0x30
created by golang.org/x/tools/go/packages.(*loader).loadRecursive.func1 in goroutine 57
	/Users/Oleksandr_Redko/go/pkg/mod/golang.org/x/tools@v0.0.0-20190321232350-e250d351ecad/go/packages/packages.go:567 +0x84
FAIL	github.com/gostaticanalysis/forcetypeassert	1.044s
FAIL

```

</p>
</details> 